### PR TITLE
右側の画像がデカすぎる

### DIFF
--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -106,8 +106,7 @@ main .appimg {
 }
 
 main .appimg img {
-  max-width: 100%;
-  max-height: 100%;
+  max-width: 75%;
   object-fit: contain;
 }
 


### PR DESCRIPTION
close #40

# 概要

* PC版の画像サイズが大きすぎるので小さくした

# 変更内容

* 画像ラッパーの最大横幅を縮めた

# その他

![7](https://user-images.githubusercontent.com/32848922/34988228-5eb8f2ec-fb01-11e7-86ee-7d8c0e655775.png)
